### PR TITLE
chore: Warn of breaking v0.131.0 release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,6 +86,9 @@ parts:
     build-packages:
       - wget
     override-build: |
+      # WARNING: Do not bump to >= 0.131.0 since it removes the loki exporter
+      # https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/12
+      
       # Create the binary
       wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.130.0/config.yaml -O ${CRAFT_PART_BUILD}/snap/config.yaml
       wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.130.0/manifest.yaml -O ${CRAFT_PART_BUILD}/snap/manifest.yaml


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
- https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/12
- https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.131.0
