### PR TITLE
feat(build): build for ppc64el, s390x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ base: core24
 platforms:
   amd64:
   arm64:
+  ppc64el:
+  s390x:
 confinement: strict
 plugs:
   etc-otelcol-config:


### PR DESCRIPTION
Confirmed on my end first that the [build succeeds](https://launchpad.net/~sed-i/sed-i-craft-remote-build/+snap/snapcraft-opentelemetry-collector-7b2618f9c152abe0360aa400f11ec667).

In tandem with:
- https://github.com/canonical/grafana-agent-snap/pull/96.