### PR TITLE
Do not remote-build amd64, arm64

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install dependencies
         run: |
           # Install just

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -12,16 +12,50 @@ env:
   LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
 
 jobs:
-  build:
-    name: Build snap (${{ matrix.confinement }})
+  local-build:
+    name: Build snap (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ "ubuntu-latest", "Ubuntu_ARM64_4C_16G_03" ]
+        include:
+        - runner: "ubuntu-latest"
+          platform: amd64
+        - runner: "Ubuntu_ARM64_4C_16G_03"
+          platform: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+
+      - name: Build Snap
+        run: snapcraft pack
+      
+      - name: Upload snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: otelcol-${{ matrix.platform }}-snap
+          path: "*.snap"
+
+  remote-build:
+    name: Build snap (${{ matrix.build-for }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        confinement: [ "strict"]
+        build-for: [ "ppc64el", "s390x" ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # snapcraft remote-build requires a full clone
           fetch-depth: 0
@@ -40,8 +74,11 @@ jobs:
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
 
-      - name: yq - portable yaml processor
-        uses: mikefarah/yq@v4
-
       - name: Build Snap (remote)
-        run: snapcraft remote-build --launchpad-accept-public-upload
+        run: snapcraft remote-build --build-for=${{ matrix.build-for }} --launchpad-accept-public-upload
+      
+      - name: Upload snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: otelcol-${{ matrix.build-for }}-snap
+          path: "*.snap"

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -26,10 +26,10 @@ jobs:
           platform: arm64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@v0.1.3
         with:
           channel: latest/stable
 
@@ -55,13 +55,13 @@ jobs:
         build-for: [ "ppc64el", "s390x" ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # snapcraft remote-build requires a full clone
           fetch-depth: 0
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@v0.1.3
         with:
           channel: latest/stable
 

--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -23,13 +23,13 @@ jobs:
           sudo snap install yq
 
       - id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        uses: pozetroninc/github-action-get-latest-release@v0.8.0
         with:
           repository: open-telemetry/opentelemetry-collector-releases
           excludes: prerelease, draft
 
       - name: Checkout the Snap source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: main
 


### PR DESCRIPTION
Currently, we remote-build everything.
This occasionally fails when the launchpad machines are busy.

This PR builds arm64 and amd64 using github runners, instead of launchpad.

Drive-by:
- By using a matrix, if a job fails, we can then re-run per individual platform, which we couldn't do previously.
- The built snaps are also uploaded as an artifact, so can be downloaded for immediate testing.