### PR TITLE
feat: snap for version 0.147.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: opentelemetry-collector
-version: '0.138.0'
+version: '0.147.0'
 summary: Vendor-agnostic way to receive, process and export telemetry data.
 description: |
   Designed to collect, process, and export telemetry data such as metrics, logs,
@@ -63,11 +63,11 @@ parts:
     plugin: go
     source: "https://github.com/open-telemetry/opentelemetry-collector.git"
     source-type: "git"
-    source-tag: "v0.138.0"
+    source-tag: "v0.147.0"
     source-depth: 1
     source-subdir: "cmd/builder"
     build-snaps:
-      - go/1.23/stable
+      - go/1.25/candidate
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: linux
@@ -84,8 +84,8 @@ parts:
       - wget
     override-build: |
       # Create the binary
-      wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.138.0/config.yaml -O ${CRAFT_PART_BUILD}/snap/config.yaml
-      wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.138.0/manifest.yaml -O ${CRAFT_PART_BUILD}/snap/manifest.yaml
+      wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.147.0/config.yaml -O ${CRAFT_PART_BUILD}/snap/config.yaml
+      wget https://raw.githubusercontent.com/canonical/opentelemetry-collector-rock/refs/heads/main/0.147.0/manifest.yaml -O ${CRAFT_PART_BUILD}/snap/manifest.yaml
       builder --config="${CRAFT_PART_BUILD}/snap/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/bin/otelcol
       install -D ${CRAFT_PART_BUILD}/snap/config.yaml ${CRAFT_PART_INSTALL}/etc/config.yaml


### PR DESCRIPTION
Manual update to follow upstream [release](https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.147.0) of opentelemetry-collector. This PR is the same as #69, except it bumps the Go lang version too.