### PR TITLE
feat: add build and release snap workflows for branch 0.130

### DIFF
--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -1,0 +1,45 @@
+name: Build Snap
+
+on:
+  workflow_dispatch:
+  # FIXME: Remove the push trigger below before merging to main. It is only here to test the workflow from the feature branch.
+  push:
+    branches:
+      - feat/ci-build-release
+
+jobs:
+  build:
+    name: Build snap (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64, ppc64el, s390x]
+    env:
+      LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # snapcraft remote-build requires a full clone
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          mkdir -p ~/.local/share/snapcraft
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
+
+      - name: Build snap (${{ matrix.arch }})
+        run: snapcraft remote-build --build-for=${{ matrix.arch }} --launchpad-accept-public-upload
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: otelcol-${{ matrix.arch }}-snap
+          path: "*.snap"

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -1,0 +1,74 @@
+name: Release Snap
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: Snap Store track to release to (edge channel)
+        type: choice
+        required: true
+        options:
+          - latest
+          - '0.130'
+      build_run_id:
+        description: Run ID from the "Build Snap" workflow (leave empty to use the latest successful build)
+        type: string
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+jobs:
+  release:
+    name: Release snap to ${{ inputs.track }}/edge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo snap install --classic --channel edge snapcraft
+
+      - name: Resolve build run ID
+        id: resolve-build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.build_run_id }}" ]; then
+            echo "run_id=${{ inputs.build_run_id }}" >> "$GITHUB_OUTPUT"
+            echo "Using provided run ID: ${{ inputs.build_run_id }}"
+          else
+            branch=$([[ "${{ inputs.track }}" == "latest" ]] && echo "main" || echo "${{ inputs.track }}")
+            run_id=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow build-snap.yaml \
+              --branch "$branch" \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+            if [ -z "$run_id" ]; then
+              echo "No successful build found for branch $branch" >&2
+              exit 1
+            fi
+            echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+            echo "Auto-detected run ID: $run_id (latest successful build on $branch)"
+          fi
+
+      - name: Download snaps from build run
+        uses: actions/download-artifact@v4
+        with:
+          pattern: otelcol-*-snap
+          run-id: ${{ steps.resolve-build.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true
+
+      - name: Release snaps to ${{ inputs.track }}/edge
+        run: |
+          for snap in *.snap; do
+            snapcraft upload "$snap" --release "${{ inputs.track }}/edge"
+          done


### PR DESCRIPTION
This PR is the same as https://github.com/canonical/opentelemetry-collector-snap/pull/78, but for branch 0.130